### PR TITLE
Aliases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lit_ipsum (0.9.6)
+    lit_ipsum (0.9.7)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/lit_ipsum/austen/pride_and_prejudice.rb
+++ b/lib/lit_ipsum/austen/pride_and_prejudice.rb
@@ -16,4 +16,6 @@ module LitIpsum
       end
     end
   end
+  # Shorthand Alias
+  PrideAndPrejudice = Austen::PrideAndPrejudice
 end

--- a/lib/lit_ipsum/austen/sense_and_sensibility.rb
+++ b/lib/lit_ipsum/austen/sense_and_sensibility.rb
@@ -16,4 +16,6 @@ module LitIpsum
       end
     end
   end
+  # Shorthand Alias
+  SenseAndSensibility = Austen::SenseAndSensibility
 end

--- a/lib/lit_ipsum/carroll/alice_in_wonderland.rb
+++ b/lib/lit_ipsum/carroll/alice_in_wonderland.rb
@@ -16,4 +16,6 @@ module LitIpsum
       end
     end
   end
+  # Shorthand Alias
+  AliceInWonderland = Carroll::AliceInWonderland
 end

--- a/lib/lit_ipsum/dickens/oliver_twist.rb
+++ b/lib/lit_ipsum/dickens/oliver_twist.rb
@@ -16,4 +16,6 @@ module LitIpsum
       end
     end
   end
+  # Shorthand Alias
+  OliverTwist = Dickens::OliverTwist
 end

--- a/lib/lit_ipsum/doyle/sherlock_holmes.rb
+++ b/lib/lit_ipsum/doyle/sherlock_holmes.rb
@@ -16,4 +16,6 @@ module LitIpsum
       end
     end
   end
+  # Shorthand Alias
+  SherlockHolmes = Doyle::SherlockHolmes
 end

--- a/lib/lit_ipsum/poe/raven.rb
+++ b/lib/lit_ipsum/poe/raven.rb
@@ -16,4 +16,6 @@ module LitIpsum
       end
     end
   end
+  # Shorthand Alias
+  Raven = Poe::Raven
 end

--- a/lib/lit_ipsum/poe/usher.rb
+++ b/lib/lit_ipsum/poe/usher.rb
@@ -16,4 +16,6 @@ module LitIpsum
       end
     end
   end
+  # Shorthand Alias
+  Usher = Poe::Usher
 end

--- a/lib/lit_ipsum/version.rb
+++ b/lib/lit_ipsum/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LitIpsum
-  VERSION = '0.9.6'
+  VERSION = '0.9.7'
 end

--- a/spec/lit_ipsum/austen/pride_and_prejudice_spec.rb
+++ b/spec/lit_ipsum/austen/pride_and_prejudice_spec.rb
@@ -2,29 +2,29 @@
 
 require 'lit_ipsum/austen/pride_and_prejudice'
 
-RSpec.describe LitIpsum::Austen::PrideAndPrejudice do
+RSpec.describe LitIpsum::PrideAndPrejudice do
   it 'generates litsum from sentences' do
     5.times do
       rand = (3..24).to_a.sample
-      expect(LitIpsum::Austen::PrideAndPrejudice.sentences(rand).is_a?(String)).to eq(true)
+      expect(LitIpsum::PrideAndPrejudice.sentences(rand).is_a?(String)).to eq(true)
     end
   end
 
   it 'generates litsum with correct amount of sentences' do
     5.times do
       rand = (1..12).to_a.sample
-      expect(LitIpsum::Austen::PrideAndPrejudice.sentences(rand).scan(LitIpsum::SENTENCE_PATTERN).size).to eq(rand)
+      expect(LitIpsum::PrideAndPrejudice.sentences(rand).scan(LitIpsum::SENTENCE_PATTERN).size).to eq(rand)
     end
   end
 
   it 'includes only sentences under or equal to maximum size limit' do
     5.times do
       rand = (1..12).to_a.sample
-      expect(LitIpsum::Austen::PrideAndPrejudice.sentences(rand, 5).scan(LitIpsum::SENTENCE_PATTERN).map(&:size).max).to be <= 5
+      expect(LitIpsum::PrideAndPrejudice.sentences(rand, 5).scan(LitIpsum::SENTENCE_PATTERN).map(&:size).max).to be <= 5
     end
   end
 
   it 'generates litsum from words' do
-    expect(LitIpsum::Austen::PrideAndPrejudice.words(8).is_a?(String)).to eq(true)
+    expect(LitIpsum::PrideAndPrejudice.words(8).is_a?(String)).to eq(true)
   end
 end

--- a/spec/lit_ipsum/austen/sense_and_sensibility_spec.rb
+++ b/spec/lit_ipsum/austen/sense_and_sensibility_spec.rb
@@ -2,29 +2,29 @@
 
 require 'lit_ipsum/austen/sense_and_sensibility'
 
-RSpec.describe LitIpsum::Austen::SenseAndSensibility do
+RSpec.describe LitIpsum::SenseAndSensibility do
   it 'generates litsum from sentences' do
     5.times do
       rand = (3..24).to_a.sample
-      expect(LitIpsum::Austen::SenseAndSensibility.sentences(rand).is_a?(String)).to eq(true)
+      expect(LitIpsum::SenseAndSensibility.sentences(rand).is_a?(String)).to eq(true)
     end
   end
 
   it 'generates litsum with correct amount of sentences' do
     5.times do
       rand = (1..12).to_a.sample
-      expect(LitIpsum::Austen::SenseAndSensibility.sentences(rand).scan(LitIpsum::SENTENCE_PATTERN).size).to eq(rand)
+      expect(LitIpsum::SenseAndSensibility.sentences(rand).scan(LitIpsum::SENTENCE_PATTERN).size).to eq(rand)
     end
   end
 
   it 'includes only sentences under or equal to maximum size limit' do
     5.times do
       rand = (1..12).to_a.sample
-      expect(LitIpsum::Austen::SenseAndSensibility.sentences(rand, 5).scan(LitIpsum::SENTENCE_PATTERN).map(&:size).max).to be <= 5
+      expect(LitIpsum::SenseAndSensibility.sentences(rand, 5).scan(LitIpsum::SENTENCE_PATTERN).map(&:size).max).to be <= 5
     end
   end
 
   it 'generates litsum from words' do
-    expect(LitIpsum::Austen::SenseAndSensibility.words(8).is_a?(String)).to eq(true)
+    expect(LitIpsum::SenseAndSensibility.words(8).is_a?(String)).to eq(true)
   end
 end

--- a/spec/lit_ipsum/carroll/alice_in_wonderland_spec.rb
+++ b/spec/lit_ipsum/carroll/alice_in_wonderland_spec.rb
@@ -2,29 +2,29 @@
 
 require 'lit_ipsum/carroll/alice_in_wonderland'
 
-RSpec.describe LitIpsum::Carroll::AliceInWonderland do
+RSpec.describe LitIpsum::AliceInWonderland do
   it 'generates litsum from sentences' do
     3.times do
       rand = (3..24).to_a.sample
-      expect(LitIpsum::Carroll::AliceInWonderland.sentences(rand).is_a?(String)).to eq(true)
+      expect(LitIpsum::AliceInWonderland.sentences(rand).is_a?(String)).to eq(true)
     end
   end
 
   it 'generates litsum with correct amount of sentences' do
     3.times do
       rand = (1..12).to_a.sample
-      expect(LitIpsum::Carroll::AliceInWonderland.sentences(rand).scan(LitIpsum::SENTENCE_PATTERN).size).to eq(rand)
+      expect(LitIpsum::AliceInWonderland.sentences(rand).scan(LitIpsum::SENTENCE_PATTERN).size).to eq(rand)
     end
   end
 
   it 'includes only sentences under or equal to maximum size limit' do
     3.times do
       rand = (1..12).to_a.sample
-      expect(LitIpsum::Carroll::AliceInWonderland.sentences(rand, 5).scan(LitIpsum::SENTENCE_PATTERN).map(&:size).max).to be <= 5
+      expect(LitIpsum::AliceInWonderland.sentences(rand, 5).scan(LitIpsum::SENTENCE_PATTERN).map(&:size).max).to be <= 5
     end
   end
 
   it 'generates litsum from words' do
-    expect(LitIpsum::Carroll::AliceInWonderland.words(8).is_a?(String)).to eq(true)
+    expect(LitIpsum::AliceInWonderland.words(8).is_a?(String)).to eq(true)
   end
 end

--- a/spec/lit_ipsum/dickens/oliver_twist_spec.rb
+++ b/spec/lit_ipsum/dickens/oliver_twist_spec.rb
@@ -2,29 +2,29 @@
 
 require 'lit_ipsum/dickens/oliver_twist'
 
-RSpec.describe LitIpsum::Dickens::OliverTwist do
+RSpec.describe LitIpsum::OliverTwist do
   it 'generates litsum from sentences' do
     3.times do
       rand = (3..24).to_a.sample
-      expect(LitIpsum::Dickens::OliverTwist.sentences(rand).is_a?(String)).to eq(true)
+      expect(LitIpsum::OliverTwist.sentences(rand).is_a?(String)).to eq(true)
     end
   end
 
   it 'generates litsum with correct amount of sentences' do
     3.times do
       rand = (1..12).to_a.sample
-      expect(LitIpsum::Dickens::OliverTwist.sentences(rand).scan(LitIpsum::SENTENCE_PATTERN).size).to eq(rand)
+      expect(LitIpsum::OliverTwist.sentences(rand).scan(LitIpsum::SENTENCE_PATTERN).size).to eq(rand)
     end
   end
 
   it 'includes only sentences under or equal to maximum size limit' do
     3.times do
       rand = (1..12).to_a.sample
-      expect(LitIpsum::Dickens::OliverTwist.sentences(rand, 5).scan(LitIpsum::SENTENCE_PATTERN).map(&:size).max).to be <= 5
+      expect(LitIpsum::OliverTwist.sentences(rand, 5).scan(LitIpsum::SENTENCE_PATTERN).map(&:size).max).to be <= 5
     end
   end
 
   it 'generates litsum from words' do
-    expect(LitIpsum::Dickens::OliverTwist.words(8).is_a?(String)).to eq(true)
+    expect(LitIpsum::OliverTwist.words(8).is_a?(String)).to eq(true)
   end
 end

--- a/spec/lit_ipsum/doyle/sherlock_holmes_spec.rb
+++ b/spec/lit_ipsum/doyle/sherlock_holmes_spec.rb
@@ -2,29 +2,29 @@
 
 require 'lit_ipsum/doyle/sherlock_holmes'
 
-RSpec.describe LitIpsum::Doyle::SherlockHolmes do
+RSpec.describe LitIpsum::SherlockHolmes do
   it 'generates litsum from sentences' do
     3.times do
       rand = (3..24).to_a.sample
-      expect(LitIpsum::Doyle::SherlockHolmes.sentences(rand).is_a?(String)).to eq(true)
+      expect(LitIpsum::SherlockHolmes.sentences(rand).is_a?(String)).to eq(true)
     end
   end
 
   it 'generates litsum with correct amount of sentences' do
     3.times do
       rand = (1..12).to_a.sample
-      expect(LitIpsum::Doyle::SherlockHolmes.sentences(rand).scan(LitIpsum::SENTENCE_PATTERN).size).to eq(rand)
+      expect(LitIpsum::SherlockHolmes.sentences(rand).scan(LitIpsum::SENTENCE_PATTERN).size).to eq(rand)
     end
   end
 
   it 'includes only sentences under or equal to maximum size limit' do
     3.times do
       rand = (1..12).to_a.sample
-      expect(LitIpsum::Doyle::SherlockHolmes.sentences(rand, 5).scan(LitIpsum::SENTENCE_PATTERN).map(&:size).max).to be <= 5
+      expect(LitIpsum::SherlockHolmes.sentences(rand, 5).scan(LitIpsum::SENTENCE_PATTERN).map(&:size).max).to be <= 5
     end
   end
 
   it 'generates litsum from words' do
-    expect(LitIpsum::Doyle::SherlockHolmes.words(8).is_a?(String)).to eq(true)
+    expect(LitIpsum::SherlockHolmes.words(8).is_a?(String)).to eq(true)
   end
 end

--- a/spec/lit_ipsum/poe/raven_spec.rb
+++ b/spec/lit_ipsum/poe/raven_spec.rb
@@ -2,29 +2,29 @@
 
 require 'lit_ipsum/poe/raven'
 
-RSpec.describe LitIpsum::Poe::Raven do
+RSpec.describe LitIpsum::Raven do
   it 'generates litsum from sentences' do
     3.times do
       rand = (3..24).to_a.sample
-      expect(LitIpsum::Poe::Raven.sentences(rand).is_a?(String)).to eq(true)
+      expect(LitIpsum::Raven.sentences(rand).is_a?(String)).to eq(true)
     end
   end
 
   it 'generates litsum with correct amount of sentences' do
     3.times do
       rand = (1..12).to_a.sample
-      expect(LitIpsum::Poe::Raven.sentences(rand).scan(LitIpsum::SENTENCE_PATTERN).size).to eq(rand)
+      expect(LitIpsum::Raven.sentences(rand).scan(LitIpsum::SENTENCE_PATTERN).size).to eq(rand)
     end
   end
 
   it 'includes only sentences under or equal to maximum size limit' do
     3.times do
       rand = (1..12).to_a.sample
-      expect { LitIpsum::Poe::Raven.sentences(rand, 5) }.to raise_error(LitIpsum::Error)
+      expect { LitIpsum::Raven.sentences(rand, 5) }.to raise_error(LitIpsum::Error)
     end
   end
 
   it 'generates litsum from words' do
-    expect(LitIpsum::Poe::Raven.words(8).is_a?(String)).to eq(true)
+    expect(LitIpsum::Raven.words(8).is_a?(String)).to eq(true)
   end
 end

--- a/spec/lit_ipsum/poe/usher_spec.rb
+++ b/spec/lit_ipsum/poe/usher_spec.rb
@@ -2,29 +2,29 @@
 
 require 'lit_ipsum/poe/usher'
 
-RSpec.describe LitIpsum::Poe::Usher do
+RSpec.describe LitIpsum::Usher do
   it 'generates litsum from sentences' do
     3.times do
       rand = (3..24).to_a.sample
-      expect(LitIpsum::Poe::Usher.sentences(rand).is_a?(String)).to eq(true)
+      expect(LitIpsum::Usher.sentences(rand).is_a?(String)).to eq(true)
     end
   end
 
   it 'generates litsum with correct amount of sentences' do
     3.times do
       rand = (1..12).to_a.sample
-      expect(LitIpsum::Poe::Usher.sentences(rand).scan(LitIpsum::SENTENCE_PATTERN).size).to eq(rand)
+      expect(LitIpsum::Usher.sentences(rand).scan(LitIpsum::SENTENCE_PATTERN).size).to eq(rand)
     end
   end
 
   it 'includes only sentences under or equal to maximum size limit' do
     3.times do
       rand = (1..12).to_a.sample
-      expect { LitIpsum::Poe::Usher.sentences(rand, 5) }.to raise_error(LitIpsum::Error)
+      expect { LitIpsum::Usher.sentences(rand, 5) }.to raise_error(LitIpsum::Error)
     end
   end
 
   it 'generates litsum from words' do
-    expect(LitIpsum::Poe::Usher.words(8).is_a?(String)).to eq(true)
+    expect(LitIpsum::Usher.words(8).is_a?(String)).to eq(true)
   end
 end


### PR DESCRIPTION
From Issue #11 (The Roadmap to 1.0.0):

> Re-evaluate naming conventions. How can I reduce the number of keystrokes required to use this gem. For example, LitIpsum::Austen::PrideAndPrejudice.sentences(8) is a lot to type out to generate ipsum text. I'd like to explore creating alias classes for each text that can be used as shorthand. With the above example, this might mean LitIpsum::PrideAndPrejudices.sentences(8).

In this branch, I add a shorthand class for each text's class. For example, `LitIpsum::SherlockHolmes` in place of `LitIpsum::Doyle::SherlockHolmes. I toyed with the idea of paring down the name further (e.g. `LitIpsum::Sherlock`), but decided against it as this keeps the shorthand class more consistent with the more traditional naming structure.

Ultimately, my aim with this fix is to increase the day-to-day usability for this gem. In most cases, this will save users at least 5-6 keystrokes with each invocation a class from this gem.